### PR TITLE
feat: Add tool schemas for arXiv searcher functions

### DIFF
--- a/arxiv_tool_schemas.py
+++ b/arxiv_tool_schemas.py
@@ -1,0 +1,44 @@
+# This file will store the tool schemas for the functions found in arxiv_searcher.py
+
+search_papers_schema = {
+    "name": "search_papers",
+    "description": "Searches arXiv for papers related to a specific topic and stores their metadata.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "topic": {
+                "type": "string",
+                "description": "The topic to search for on arXiv (e.g., 'Quantum Computing')."
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "The maximum number of search results to fetch from arXiv. Defaults to 5."
+            }
+        },
+        "required": ["topic"]
+    },
+    "returns": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "A list of paper entry_ids (unique identifiers from arXiv) found in the current search."
+    }
+}
+
+extract_info_schema = {
+    "name": "extract_info",
+    "description": "Extracts and returns the metadata of a specific paper if it has been previously saved.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "paper_id": {
+                "type": "string",
+                "description": "The entry_id of the paper to search for."
+            }
+        },
+        "required": ["paper_id"]
+    },
+    "returns": {
+        "type": "string",
+        "description": "A JSON string containing the paper's metadata if found, otherwise a message indicating the paper was not found."
+    }
+}


### PR DESCRIPTION
This creates a new file `arxiv_tool_schemas.py` containing the OpenAPI-like schemas for the `search_papers` and `extract_info` functions from `arxiv_searcher.py`.

These schemas define the functions' parameters and return values, enabling them to be used by other systems or for
automatic client generation.